### PR TITLE
support slack signup with same path under same application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# blue
+# Musicoin
+
 it's aiming to make musicians' proud of their life

--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,6 @@
 # only use these two lines with gae devserver
 application: musicoin-web
-version: 1
+version: 2
 runtime: python27
 api_version: 1
 threadsafe: yes
@@ -15,22 +15,23 @@ handlers:
 - url: /images
   static_dir: images
 
+- url: /
+  script: main.app
+
 - url: /join
-  script: join_slack.app
+  script: main.app
 
 - url: /join/.*
-  script: join_slack.app
+  script: main.app
 
 - url: /\.well-known/acme-challenge/.*
   script: letsencrypt.app
 
-- url: /
-  static_files: public/index.html
-  upload: public/index.html
 
 - url: /(.+)
   static_files: public/\1
   upload: public/(.*)
+  application_readable: true
 
 
 skip_files:

--- a/main.py
+++ b/main.py
@@ -45,6 +45,14 @@ def slack_invite(email):
 
 
 
+class HomePageHandler(webapp2.RequestHandler):
+    def get(self):
+        path = os.path.join(os.path.dirname(__file__), 'public/index.html')
+        self.response.out.write(template.render(path, {}))
+
+
+
+
 class SlackInvitePageHandler(webapp2.RequestHandler):
     def get(self):
         template_values = {
@@ -130,7 +138,11 @@ class ReturnHomePageHandler(webapp2.RequestHandler):
 app = webapp2.WSGIApplication([
     # routes.DomainRoute(r'<:(slack\.hongcoin\.org|localhost)>', [
     # Slack signup
+    routes.DomainRoute(r'<:(musicoin.org|www.musicoin.org|slack.default.musicoin-web.appspot.com)>', [
+        webapp2.Route('/', HomePageHandler),
+    ]),
     routes.DomainRoute(r'<:(slack.musicoin.org|slack.default.musicoin-web.appspot.com)>', [
+        webapp2.Route('/', SlackInvitePageHandler),
         webapp2.Route('/join', SlackInvitePageHandler),
         webapp2.Route('/join/', SlackInvitePageHandler),
         webapp2.Route('/join/invited', SlackInviteSuccessPageHandler),
@@ -139,12 +151,14 @@ app = webapp2.WSGIApplication([
 
     # Slack signup for localhost
     routes.DomainRoute(r'<:(localhost)>', [
-        webapp2.Route('/join/', SlackInvitePageHandler),
+        webapp2.Route('/', HomePageHandler),
+        webapp2.Route('/join', SlackInvitePageHandler),
         webapp2.Route('/join/', SlackInvitePageHandler),
         webapp2.Route('/join/invited', SlackInviteSuccessPageHandler),
         webapp2.Route('/join/slack/invite', SlackInviteActionHandler),
     ]),
 
+    ('/', HomePageHandler),
     ('/.*', ReturnHomePageHandler),
 
-], debug=True)
+])

--- a/public/index.html
+++ b/public/index.html
@@ -41,7 +41,7 @@
 		</div>
 
 		<div class="join_discussion_link">
-			<a href="https://slack.musicoin.org/join/" target="_blank">Join Discussion</a>
+			<a href="https://slack.musicoin.org" target="_blank">Join Discussion</a>
 		</div>
 		<br>
 		<div class="github_link">


### PR DESCRIPTION
Supporting Slack signup with https://slack.musicoin.org/ .